### PR TITLE
Use link name instead of link title

### DIFF
--- a/graphipedia-dataimport/src/main/java/org/graphipedia/dataimport/LinkExtractor.java
+++ b/graphipedia-dataimport/src/main/java/org/graphipedia/dataimport/LinkExtractor.java
@@ -97,7 +97,7 @@ public class LinkExtractor extends SimpleStaxParser {
                 String link = matcher.group(1);
                 if (!link.contains(":")) {
                     if (link.contains("|")) {
-                        link = link.substring(link.lastIndexOf('|') + 1);
+                        link = link.substring(0, link.lastIndexOf('|'));
                     }
                     links.add(link);
                 }


### PR DESCRIPTION
Hello
This pull request fixes small issue in LinkExtractor. According to [documentation](https://en.wikipedia.org/wiki/Help:Wiki_markup#Free_links ) we need to extract the first value from link markup(currently we take second).